### PR TITLE
Declare phpunit dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,5 +30,8 @@
         "psr-4": {
             "Bartlett\\Tests\\Monolog\\Handler\\": "tests/"
         }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^5.0"
     }
 }


### PR DESCRIPTION
The package's tests are not compatible with recent PHPUnit version, so depedency needs to be explicit.